### PR TITLE
add http stub/mock server

### DIFF
--- a/README.md
+++ b/README.md
@@ -58,3 +58,29 @@ Makes a request to the configured worker.
 ### `client.stop([cb]) => Promise`
 
 Stops the client.
+
+### `createServer(mocks, opts) => Server`
+
+Sets up a HTTP stub/mock server.
+
+  `opts.port` - the port the server will listen to.
+  `opts.debug` - print the data sent from the client via post
+
+`opts.debug` is useful when you are creating new mock definitions, especially
+if you use an external client library to send the request.
+
+`mocks` can be a mock definition or an array of mock definitions.
+
+The server can basically match, test and return anything on request/response,
+sent payloads etc. For convenience, there are shorthands that should suffice
+in most cases: [example-server-simple.js](example-server-simple.js).
+
+For advanced route matching and testing of incoming requests, see [example-server-advanced.js](example-server-advanced.js)
+
+### `server.start([cb]) => Promise`
+
+Makes a request to the configured mockserver.
+
+### `server.stop([cb]) => Promise`
+
+Stops the server.

--- a/example-server-advanced.js
+++ b/example-server-advanced.js
@@ -1,0 +1,48 @@
+'use strict'
+
+const createServer = require('./server')
+const request = require('request')
+const assert = require('assert')
+
+const server = createServer({
+  reply: (reply) => {
+    reply({ fruit: 'lemon' }, 404) // default: 200
+  },
+
+  // all are optional
+  match: (payload, match) => {
+    match({
+      route: '/foo',
+      method: 'POST',
+      payload: (payload, cb) => {
+        return cb(null, payload.fruit === 'mango')
+      },
+      custom: (req, res, cb) => {
+        return cb(null, true)
+      }
+    })
+  },
+
+  // makes assertions on the _sent request_
+  test: (req, res, payload, cb) => {
+    assert.ok(payload.fruit, 'missing property')
+    cb(null)
+  }
+}, { port: 1337 })
+
+;(async () => {
+  await server.start()
+
+  request({
+    uri: 'http://localhost:1337/foo',
+    json: true,
+    body: { fruit: 'mango' },
+    method: 'POST'
+  }, async (err, res, body) => {
+    if (err) throw err
+
+    console.log('response', body, res.statusCode)
+
+    await server.stop()
+  })
+})()

--- a/example-server-simple.js
+++ b/example-server-simple.js
@@ -1,0 +1,32 @@
+'use strict'
+
+const createServer = require('./server')
+const request = require('request')
+
+const server = createServer([
+  {
+    reply: { animal: 'platypus' },
+    route: '/australia'
+  },
+  {
+    reply: { animal: 'Fair Isle Wren' },
+    route: '/england'
+  }
+], { port: 1337, debug: true })
+
+;(async () => {
+  await server.start()
+
+  request({
+    uri: 'http://localhost:1337/australia',
+    json: true,
+    body: { foo: 'bar' },
+    method: 'POST'
+  }, async (err, res, body) => {
+    if (err) throw err
+
+    console.log('response', body, res.statusCode)
+
+    await server.stop()
+  })
+})()

--- a/package.json
+++ b/package.json
@@ -13,6 +13,7 @@
   "author": "Robert <robert@bitfinex.com>",
   "license": "Apache-2.0",
   "devDependencies": {
+    "request": "^2.88.0",
     "standard": "^12.0.1"
   },
   "dependencies": {

--- a/server.js
+++ b/server.js
@@ -1,0 +1,169 @@
+'use strict'
+
+const http = require('http')
+const async = require('async')
+
+class Mocks {
+  constructor (routes, opts) {
+    this.routes = this.parseRouting(routes)
+    this.debug = opts.debug
+  }
+
+  parseRouting (routes) {
+    if (!Array.isArray(routes)) {
+      routes = [ routes ]
+    }
+
+    routes = routes.map((route) => {
+      if (route.route && route.match) {
+        throw new Error(
+          'shorthand .route must be used without .match'
+        )
+      }
+
+      if (route.route) {
+        route.match = (data, match) => {
+          match({ route: route.route })
+        }
+      }
+
+      if (typeof route.reply !== 'function') {
+        const msg = route.reply
+        route.reply = (reply) => {
+          reply(msg, 200)
+        }
+      }
+
+      return route
+    })
+
+    return routes
+  }
+
+  getMock (req, res, data, cb) {
+    const match = (route, cb) => {
+      route.match(data, (filters) => {
+        if (filters.route && filters.route !== req.url) {
+          return cb(null, false)
+        }
+
+        if (filters.method && filters.method !== req.method) {
+          return cb(null, false)
+        }
+
+        if (!filters.custom) {
+          filters.custom = (req, res, cb) => {
+            return cb(null, true)
+          }
+        }
+
+        filters.custom(req, res, (err, res) => {
+          if (err) return cb(err)
+          if (res === false) return cb(null, false)
+
+          if (!filters.payload) return cb(null, res)
+
+          filters.payload(data, cb)
+        })
+      })
+    }
+
+    async.filter(this.routes, match, cb)
+  }
+
+  stubReply (req, res, mock) {
+    mock.reply((data, code) => {
+      if (code) {
+        res.statusCode = code
+      }
+
+      if (typeof data === 'object') {
+        data = JSON.stringify(data)
+      }
+
+      res.end(data)
+    })
+  }
+
+  handle (req, res) {
+    const data = []
+    req.on('data', (buf) => {
+      data.push(buf)
+    })
+
+    req.on('end', () => {
+      const str = Buffer.concat(data).toString()
+
+      this.debug && console.log('[DEBUG] bfx-svc-test-helper:', str)
+
+      let parsed
+      try {
+        parsed = JSON.parse(str)
+      } catch (e) {
+        parsed = str
+      }
+
+      this.getMock(req, res, parsed, (err, matches) => {
+        if (err) {
+          console.error('bfx-svc-test-helper: route matching error')
+          throw err
+        }
+
+        if (matches.length === 0) {
+          throw new Error('bfx-svc-test-helper: no route matched')
+        }
+
+        if (matches.length > 1) {
+          throw new Error('bfx-svc-test-helper: multiple routes matched')
+        }
+
+        const mock = matches[0]
+        if (!mock.test) mock.test = (req, res, payload, cb) => { cb(null) }
+
+        mock.test(req, res, parsed, (err) => {
+          if (err) {
+            console.error('bfx-svc-test-helper: client request test failed')
+            throw err
+          }
+
+          this.stubReply(req, res, mock)
+        })
+      })
+    })
+  }
+}
+
+class Server {
+  constructor (mocks, opts) {
+    this.opts = opts
+    this.mocks = mocks
+
+    this.server = null
+    this.port = this.opts.port
+  }
+
+  start (cb = () => {}) {
+    return new Promise((resolve, reject) => {
+      this.server = http.createServer(this.mocks.handle.bind(this.mocks)).listen(this.port, () => {
+        resolve()
+        cb(null)
+      })
+    })
+  }
+
+  stop (cb = () => {}) {
+    return new Promise((resolve, reject) => {
+      this.server.close(() => {
+        resolve()
+        cb(null)
+      })
+    })
+  }
+}
+
+function createServer (mocks, opts) {
+  const m = typeof mocks === 'function' ? mocks() : new Mocks(mocks, opts)
+  return new Server(m, opts)
+}
+
+module.exports = createServer


### PR DESCRIPTION
the server can match on routes, http method, sent payload from
client. it is also possible to match by custom assertion on
request, response and sent data. when a matching stub/mock
is found, there can be optional testing, too.

you can pass a mock definition, a list of mock definition or
a function (returning you own mock middleware) to the server.

for many use cases a simple match by route and a simple reply is
ok, so we have a convenience shortshand for this.

see example-server-simple.js and example-server-advanced.js
for each usage.