### PR TITLE
call stop method if peer and link exist

### DIFF
--- a/client.js
+++ b/client.js
@@ -65,8 +65,10 @@ class Client {
 
   stop (cb = () => {}) {
     return new Promise((resolve, reject) => {
-      this.peer.stop()
-      this.link.stop()
+      if(this.peer && this.link){
+        this.peer.stop()
+        this.link.stop()
+      }
       resolve()
       cb(null)
     })


### PR DESCRIPTION
Some tests create an instance of a client but they never use call `client.request` and so `this.peer` and `this.link` is never created, so when the test ends and `client.stop` it crashed. 
