### PR TITLE
add helper for worker.worker.api_bfx.api.method

### DIFF
--- a/README.md
+++ b/README.md
@@ -84,3 +84,7 @@ Makes a request to the configured mockserver.
 ### `server.stop([cb]) => Promise`
 
 Stops the server.
+
+### utils.getApi(worker) => Api
+
+Returns the loc.api instance of the worker

--- a/utils.js
+++ b/utils.js
@@ -1,0 +1,6 @@
+'use strict'
+
+exports.getApi = getApi
+function getApi (instance) {
+  return instance.worker.api_bfx.api
+}


### PR DESCRIPTION
returns the instance of the `loc.api` worker:

`getApi(worker).getIpInfo` replaces:

`worker.worker.api_bfx.api.getIpInfo`