### PR TITLE
client: when cb used, do not reject promise

### DIFF
--- a/client.js
+++ b/client.js
@@ -51,8 +51,8 @@ class Client {
       this.connectGrape(() => {
         this.peer.request(this.workerName, query, opts, (err, res) => {
           if (err) {
+            if (cb) return cb(err)
             reject(err)
-            cb(err)
             return
           }
 


### PR DESCRIPTION
fixes unhandled promise rejection errors when errors are returned
in cb-mode