### PR TITLE
fix add grapes on constructor not on start

### DIFF
--- a/grapes.js
+++ b/grapes.js
@@ -7,12 +7,11 @@ const EventEmitter = require('events')
 class Grapes extends EventEmitter {
   constructor (opts) {
     super()
-    this.grapes = []
+    this.grapes = this.addDefaultGrapes()
   }
 
   start (cb = () => {}) {
     return new Promise((resolve, reject) => {
-      this.addDefaultGrapes()
       const tasks = this.grapes.map((grape, i) => {
         return (cb) => {
           if (i === 0) grape.once('ready', cb)
@@ -66,21 +65,17 @@ class Grapes extends EventEmitter {
   }
 
   addDefaultGrapes () {
-    this.addGrape({
+    const g1 = new Grape({
       dht_port: 20002,
       dht_bootstrap: [ '127.0.0.1:20001' ],
       api_port: 40001
     })
-
-    this.addGrape({
+    const g2 = new Grape({
       dht_port: 20001,
       dht_bootstrap: [ '127.0.0.1:20002' ],
       api_port: 30001
     })
-  }
-
-  addGrape (opts) {
-    this.grapes.push(new Grape(opts))
+    return [ g1, g2 ]
   }
 
   stop (cb = () => {}) {


### PR DESCRIPTION
There was a bug that as grapes where added on start not on constructor it was not possible to start and stop grapes several times, as each time grapes where started there where new grapes created. 