### PR TITLE
utils: add getGrapeApiPort

### DIFF
--- a/README.md
+++ b/README.md
@@ -85,6 +85,25 @@ Makes a request to the configured mockserver.
 
 Stops the server.
 
-### utils.getApi(worker) => Api
+### `utils.getApi(worker) => Api`
 
 Returns the loc.api instance of the worker
+
+### `utils.getGrapeApiPort(grapesWorker) => port`
+
+Gets the HTTP port of one of the Grape workers
+
+Example:
+
+```js
+const createGrapes = require('bfx-svc-test-helper/grapes')
+const utils = require('bfx-svc-test-helper/utils')
+
+const grapes = createGrapes()
+
+;(async () => {
+  await grapes.start()
+  const port = utils.getGrapeApiPort(grapes)
+  console.log(port) // 30001
+})()
+```

--- a/index.js
+++ b/index.js
@@ -3,3 +3,5 @@
 exports.grapes = require('./grapes')
 exports.worker = require('./worker')
 exports.client = require('./client')
+exports.server = require('./server')
+exports.utils = require('./utils')

--- a/utils.js
+++ b/utils.js
@@ -4,3 +4,8 @@ exports.getApi = getApi
 function getApi (instance) {
   return instance.worker.api_bfx.api
 }
+
+exports.getGrapeApiPort = getGrapeApiPort
+function getGrapeApiPort (grapeHelperInstance) {
+  return grapeHelperInstance.grapes[0].conf.api_port
+}


### PR DESCRIPTION
adds a small helper function to get the api port for a test grape.
useful for more complex test setups amnd custom extensions.