### PR TITLE
fxGrenache: make grape instances optional

### DIFF
--- a/README.md
+++ b/README.md
@@ -61,12 +61,15 @@ Makes a request to the configured worker.
 
 Stops the client.
 
-### `createFxGrenache(mocks, grapes, [opts]) => FauxGrenacheServer`
+### `createFxGrenache(mocks, grapes|url, [opts]) => FauxGrenacheServer`
 
 Spins up Grenache service mocks.
 
   `opts.port` - the port the server will listen to, defaults to `1557`
   `opts.link` - custom / own link, can be used for customised setups
+
+Second parameter is either a `Grapes` instance or a http url pointing
+to the Grenache Grape HTTP Server.
 
 ### `fxgrenache.start([cb]) => Promise`
 

--- a/example-fauxgrenache.js
+++ b/example-fauxgrenache.js
@@ -17,9 +17,13 @@ const stubs = {
 
 ;(async () => {
   await grapes.start()
-
   // lets create a worker stub
-  const fxg = createFxGrenache(stubs, grapes)
+
+  // we can pass in Grape instances or an url
+  const url = 'http://localhost:30001'
+  const grape = grapes || url
+
+  const fxg = createFxGrenache(stubs, grape)
   await fxg.start()
   console.log('stub service started, announcing on grape')
 

--- a/fauxgrenache.js
+++ b/fauxgrenache.js
@@ -2,7 +2,7 @@
 
 const http = require('http')
 const Link = require('grenache-nodejs-link')
-const { getGrapeApiPort } = require('./utils')
+const { getGrapeApiUrl } = require('./utils')
 
 const getRawBody = require('raw-body')
 const async = require('async')
@@ -21,9 +21,9 @@ class FauxGrenache {
       return this.link
     }
 
-    const p = getGrapeApiPort(this.grapes)
+    const url = getGrapeApiUrl(this.grapes)
     this.link = new Link({
-      grape: 'http://127.0.0.1:' + p
+      grape: url
     })
 
     return this.link

--- a/utils.js
+++ b/utils.js
@@ -9,3 +9,13 @@ exports.getGrapeApiPort = getGrapeApiPort
 function getGrapeApiPort (grapeHelperInstance) {
   return grapeHelperInstance.grapes[0].conf.api_port
 }
+
+exports.getGrapeApiUrl = getGrapeApiUrl
+function getGrapeApiUrl (grapes) {
+  if (typeof grapes === 'string') {
+    return grapes
+  }
+
+  const p = getGrapeApiPort(this.grapes)
+  return 'http://127.0.0.1:' + p
+}


### PR DESCRIPTION
useful when there is no additional Grape instance to pass in,
e.g. when running as "standalone" in a dev setup